### PR TITLE
Add check for empty get_problems list

### DIFF
--- a/src/leetscraper/scraper.py
+++ b/src/leetscraper/scraper.py
@@ -76,6 +76,10 @@ def scrape_problems(
     """Scrapes the list of get_problems by calling the create_problem method.
     Returns a count of total problems scraped.
     """
+    if not get_problems:
+        logger = get_logger()
+        logger.warning("Nothing to scrape! get_problems is empty!")
+        return 0
     errors = 0
     start = time()
     for problem in tqdm(get_problems):


### PR DESCRIPTION
## Description

scrape_problems is called even when get_problems is an empty list

## Type of change

- [x] Bug fix. Fixes #53 

## Checklist:

- [x] I have formatted my code with black
- [x] I have checked my code with mypy
- [x] I have checked my code with pylint
- [x] I have ran the unit tests and they all pass
