### PR TITLE
Add a check for cached webdrivers to use

### DIFF
--- a/src/leetscraper/__init__.py
+++ b/src/leetscraper/__init__.py
@@ -8,6 +8,3 @@ __version__ = "2.0.2"
 __licence__ = "GPL-2.0"
 __author__ = "Pavocracy"
 __email__ = "pavocracy@pm.me"
-
-from .websites import *
-from .leetscraper import Leetscraper

--- a/src/leetscraper/leetscraper.py
+++ b/src/leetscraper/leetscraper.py
@@ -28,11 +28,12 @@ See related docstrings for help.
 
 from os import getcwd
 
-from .driver import create_webdriver, webdriver_quit
+from .driver import check_installed_webdrivers, create_webdriver, webdriver_quit
 from .logger import get_logger
 from .scraper import check_problems, needed_problems, scrape_problems
 from .system import check_path, check_platform, check_supported_browsers
 from .website import set_website
+from .__init__ import __version__
 
 
 class Leetscraper:
@@ -49,6 +50,7 @@ class Leetscraper:
 
     def __init__(self, **kwargs):
         """Initialize leetscraper with default values unless kwargs are given."""
+        self.version = __version__
         self.website = set_website(kwargs.get("website_name", "leetcode.com"))
         self.scrape_path = check_path(kwargs.get("scrape_path", getcwd()))
         self.scrape_limit = int(kwargs.get("scrape_limit", -1))
@@ -72,9 +74,19 @@ class Leetscraper:
         browsers = check_supported_browsers(user_platform)
         scraped_problems = check_problems(self.website, self.scrape_path)
         get_problems = needed_problems(
-            self.website, scraped_problems, self.scrape_limit
+            self.website,
+            scraped_problems,
+            self.scrape_limit,
+            browsers,
+            self.version,
         )
-        driver = create_webdriver(browsers, self.website.website_name)
+        installed_webdrivers = check_installed_webdrivers()
+        driver = create_webdriver(
+            browsers,
+            self.website,
+            installed_webdrivers,
+            self.version,
+        )
         return driver, get_problems
 
     def start_scraping(self) -> int:

--- a/src/leetscraper/scraper.py
+++ b/src/leetscraper/scraper.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 from urllib3 import PoolManager
 
 from .logger import get_logger
-from .driver import WebdriverType
+from .driver import header_constructor, WebdriverType
 from .website import WebsiteType
 
 
@@ -47,13 +47,22 @@ def check_problems(website: WebsiteType, scrape_path: str) -> List[str]:
 
 
 def needed_problems(
-    website: WebsiteType, scraped_problems: List[str], scrape_limit: int
+    website: WebsiteType,
+    scraped_problems: List[str],
+    scrape_limit: int,
+    browsers: dict,
+    leetscraper_version: str,
 ) -> List[List[Optional[str]]]:
     """Returns a list of scrape_limit website problems missing from the scraped_path."""
     logger = get_logger()
     logger.info("Getting the list of %s problems to scrape", website.website_name)
-    start = time()
+    if website.need_headers:
+        browser, browser_version = list(browsers.items())[0]
+        website.headers = header_constructor(
+            leetscraper_version, browser, browser_version
+        )
     http = PoolManager()
+    start = time()
     get_problems = website.get_problems(http, scraped_problems, scrape_limit)
     stop = time()
     logger.debug(

--- a/src/leetscraper/websites/codechef.py
+++ b/src/leetscraper/websites/codechef.py
@@ -28,6 +28,7 @@ class Codechef:
         self.base_url = "https://www.codechef.com/problems/"
         self.problem_description = {"class": "problem-statement"}
         self.file_split = "-"
+        self.need_headers = True
 
     def get_problems(
         self, http: PoolManager, scraped_problems: List[str], scrape_limit: int
@@ -35,10 +36,13 @@ class Codechef:
         """Returns problems to scrape defined by checks in this method."""
         get_problems = []
         try:
+            headers = {}
+            headers["User-Agent"] = self.headers
             for value in self.difficulty.values():
                 request = http.request(
                     "GET",
                     self.api_url + value.lower() + "?limit=999",
+                    headers=headers,
                 )
                 data = loads(request.data.decode("utf-8"))
                 for problem in data["data"]:

--- a/src/leetscraper/websites/codewars.py
+++ b/src/leetscraper/websites/codewars.py
@@ -36,6 +36,7 @@ class Codewars:
         self.base_url = "https://www.codewars.com/kata/"
         self.problem_description = {"id": "description"}
         self.file_split = "."
+        self.need_headers = True
 
     def get_problems(
         self, http: PoolManager, scraped_problems: List[str], scrape_limit: int
@@ -43,13 +44,19 @@ class Codewars:
         """Returns problems to scrape defined by checks in this method."""
         get_problems = []
         try:
+            headers = {}
+            headers["User-Agent"] = self.headers
             if scrape_limit == -1 or scrape_limit > 999:
                 logger = get_logger()
                 logger.info(
                     "**NOTE** codewars can take up to 5 minutes to find all problems!"
                 )
             for i in range(0, 999):
-                request = http.request("GET", self.base_url + f"?page={i}")
+                request = http.request(
+                    "GET",
+                    self.base_url + f"?page={i}",
+                    headers=headers,
+                )
                 soup = BeautifulSoup(request.data, "html.parser")
                 data = soup.find_all("div", {"class": "list-item-kata"})
                 if data:

--- a/src/leetscraper/websites/hackerrank.py
+++ b/src/leetscraper/websites/hackerrank.py
@@ -13,7 +13,6 @@ from typing import List, Optional
 from urllib3 import PoolManager
 
 from ..logger import get_logger
-from ..system import check_platform, check_supported_browsers
 
 
 class Hackerrank:
@@ -28,9 +27,7 @@ class Hackerrank:
         self.base_url = "https://www.hackerrank.com/challenges/"
         self.problem_description = {"class": "problem-statement"}
         self.file_split = "."
-        # Hackerrank requires User-Agent headers for scraping.
-        platform = check_platform()
-        self.browsers = check_supported_browsers(platform)
+        self.need_headers = True
 
     def get_problems(
         self, http: PoolManager, scraped_problems: List[str], scrape_limit: int
@@ -39,8 +36,7 @@ class Hackerrank:
         get_problems = []
         try:
             headers = {}
-            browser, version = list(self.browsers.items())[0]
-            headers["User-Agent"] = f"{browser}/{version}"
+            headers["User-Agent"] = self.headers
             for category in self.categories:
                 for i in range(0, 1001, 50):
                     request = http.request(

--- a/src/leetscraper/websites/leetcode.py
+++ b/src/leetscraper/websites/leetcode.py
@@ -27,6 +27,7 @@ class Leetcode:
         self.base_url = "https://leetcode.com/problems/"
         self.problem_description = {"class": "content__u3I1 question-content__JfgR"}
         self.file_split = "."
+        self.need_headers = False
 
     def get_problems(
         self, http: PoolManager, scraped_problems: List[str], scrape_limit: int

--- a/src/leetscraper/websites/projecteuler.py
+++ b/src/leetscraper/websites/projecteuler.py
@@ -28,6 +28,7 @@ class Projecteuler:
         self.base_url = "https://projecteuler.net/problem="
         self.problem_description = {"id": "content"}
         self.file_split = "-"
+        self.need_headers = True
 
     def get_problems(
         self, http: PoolManager, scraped_problems: List[str], scrape_limit: int
@@ -35,7 +36,9 @@ class Projecteuler:
         """Returns problems to scrape defined by checks in this method."""
         get_problems = []
         try:
-            request = http.request("GET", self.api_url)
+            headers = {}
+            headers["User-Agent"] = self.headers
+            request = http.request("GET", self.api_url, headers=headers)
             soup = BeautifulSoup(request.data, "html.parser")
             data = soup.find("td", {"class": "id_column"}).get_text()
             for i in range(1, int(data) + 1):

--- a/tests/test_codechef.py
+++ b/tests/test_codechef.py
@@ -4,7 +4,11 @@ from shutil import rmtree
 from os import path
 
 from src.leetscraper.leetscraper import Leetscraper
-from src.leetscraper.driver import create_webdriver, webdriver_quit
+from src.leetscraper.driver import (
+    check_installed_webdrivers,
+    create_webdriver,
+    webdriver_quit,
+)
 from src.leetscraper.scraper import check_problems, needed_problems, scrape_problems
 from src.leetscraper.system import check_platform, check_supported_browsers
 
@@ -40,6 +44,8 @@ class TestLeetscraper(unittest.TestCase):
             leetscraper.website,
             scraped_problems,
             leetscraper.scrape_limit * len(avaliable_browsers),
+            avaliable_browsers,
+            leetscraper.version,
         )
         self.assertEqual(
             len(get_problems), (leetscraper.scrape_limit * len(avaliable_browsers))
@@ -49,9 +55,13 @@ class TestLeetscraper(unittest.TestCase):
         total_scraped = 0
         test_browser = 1
         start = 0
+        installed_webdrivers = check_installed_webdrivers()
         for browser, version in avaliable_browsers.items():
             driver = create_webdriver(
-                {browser: version}, leetscraper.website.website_name
+                {browser: version},
+                leetscraper.website,
+                installed_webdrivers,
+                leetscraper.version,
             )
 
             # Check scrape_problems with scrape_limit

--- a/tests/test_codewars.py
+++ b/tests/test_codewars.py
@@ -4,7 +4,11 @@ from shutil import rmtree
 from os import path
 
 from src.leetscraper.leetscraper import Leetscraper
-from src.leetscraper.driver import create_webdriver, webdriver_quit
+from src.leetscraper.driver import (
+    check_installed_webdrivers,
+    create_webdriver,
+    webdriver_quit,
+)
 from src.leetscraper.scraper import check_problems, needed_problems, scrape_problems
 from src.leetscraper.system import check_platform, check_supported_browsers
 
@@ -40,6 +44,8 @@ class TestLeetscraper(unittest.TestCase):
             leetscraper.website,
             scraped_problems,
             leetscraper.scrape_limit * len(avaliable_browsers),
+            avaliable_browsers,
+            leetscraper.version,
         )
         self.assertEqual(
             len(get_problems), (leetscraper.scrape_limit * len(avaliable_browsers))
@@ -49,9 +55,13 @@ class TestLeetscraper(unittest.TestCase):
         total_scraped = 0
         test_browser = 1
         start = 0
+        installed_webdrivers = check_installed_webdrivers()
         for browser, version in avaliable_browsers.items():
             driver = create_webdriver(
-                {browser: version}, leetscraper.website.website_name
+                {browser: version},
+                leetscraper.website,
+                installed_webdrivers,
+                leetscraper.version,
             )
 
             # Check scrape_problems with scrape_limit

--- a/tests/test_hackerrank.py
+++ b/tests/test_hackerrank.py
@@ -4,7 +4,11 @@ from shutil import rmtree
 from os import path
 
 from src.leetscraper.leetscraper import Leetscraper
-from src.leetscraper.driver import create_webdriver, webdriver_quit
+from src.leetscraper.driver import (
+    check_installed_webdrivers,
+    create_webdriver,
+    webdriver_quit,
+)
 from src.leetscraper.scraper import check_problems, needed_problems, scrape_problems
 from src.leetscraper.system import check_platform, check_supported_browsers
 
@@ -40,6 +44,8 @@ class TestLeetscraper(unittest.TestCase):
             leetscraper.website,
             scraped_problems,
             leetscraper.scrape_limit * len(avaliable_browsers),
+            avaliable_browsers,
+            leetscraper.version,
         )
         self.assertEqual(
             len(get_problems), (leetscraper.scrape_limit * len(avaliable_browsers))
@@ -49,9 +55,13 @@ class TestLeetscraper(unittest.TestCase):
         total_scraped = 0
         test_browser = 1
         start = 0
+        installed_webdrivers = check_installed_webdrivers()
         for browser, version in avaliable_browsers.items():
             driver = create_webdriver(
-                {browser: version}, leetscraper.website.website_name
+                {browser: version},
+                leetscraper.website,
+                installed_webdrivers,
+                leetscraper.version,
             )
 
             # Check scrape_problems with scrape_limit

--- a/tests/test_invalid_input.py
+++ b/tests/test_invalid_input.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.leetscraper import Leetscraper
+from src.leetscraper.leetscraper import Leetscraper
 
 
 class TestLeetscraper(unittest.TestCase):

--- a/tests/test_leetcode.py
+++ b/tests/test_leetcode.py
@@ -4,7 +4,11 @@ from shutil import rmtree
 from os import path
 
 from src.leetscraper.leetscraper import Leetscraper
-from src.leetscraper.driver import create_webdriver, webdriver_quit
+from src.leetscraper.driver import (
+    check_installed_webdrivers,
+    create_webdriver,
+    webdriver_quit,
+)
 from src.leetscraper.scraper import check_problems, needed_problems, scrape_problems
 from src.leetscraper.system import check_platform, check_supported_browsers
 
@@ -40,6 +44,8 @@ class TestLeetscraper(unittest.TestCase):
             leetscraper.website,
             scraped_problems,
             leetscraper.scrape_limit * len(avaliable_browsers),
+            avaliable_browsers,
+            leetscraper.version,
         )
         self.assertEqual(
             len(get_problems), (leetscraper.scrape_limit * len(avaliable_browsers))
@@ -49,9 +55,13 @@ class TestLeetscraper(unittest.TestCase):
         total_scraped = 0
         test_browser = 1
         start = 0
+        installed_webdrivers = check_installed_webdrivers()
         for browser, version in avaliable_browsers.items():
             driver = create_webdriver(
-                {browser: version}, leetscraper.website.website_name
+                {browser: version},
+                leetscraper.website,
+                installed_webdrivers,
+                leetscraper.version,
             )
 
             # Check scrape_problems with scrape_limit

--- a/tests/test_projecteuler.py
+++ b/tests/test_projecteuler.py
@@ -4,7 +4,11 @@ from shutil import rmtree
 from os import path
 
 from src.leetscraper.leetscraper import Leetscraper
-from src.leetscraper.driver import create_webdriver, webdriver_quit
+from src.leetscraper.driver import (
+    check_installed_webdrivers,
+    create_webdriver,
+    webdriver_quit,
+)
 from src.leetscraper.scraper import check_problems, needed_problems, scrape_problems
 from src.leetscraper.system import check_platform, check_supported_browsers
 
@@ -40,6 +44,8 @@ class TestLeetscraper(unittest.TestCase):
             leetscraper.website,
             scraped_problems,
             leetscraper.scrape_limit * len(avaliable_browsers),
+            avaliable_browsers,
+            leetscraper.version,
         )
         self.assertEqual(
             len(get_problems), (leetscraper.scrape_limit * len(avaliable_browsers))
@@ -49,9 +55,13 @@ class TestLeetscraper(unittest.TestCase):
         total_scraped = 0
         test_browser = 1
         start = 0
+        installed_webdrivers = check_installed_webdrivers()
         for browser, version in avaliable_browsers.items():
             driver = create_webdriver(
-                {browser: version}, leetscraper.website.website_name
+                {browser: version},
+                leetscraper.website,
+                installed_webdrivers,
+                leetscraper.version,
             )
 
             # Check scrape_problems with scrape_limit


### PR DESCRIPTION
## Description

Added a check for cached webdrivers to use, instead of allowing webdriver_manager to request the latest version every time.
This helps avoid the rate limits from github when using geckodriver.

## Type of change

- [x] New feature (non-breaking change which adds functionality or website support)
- [x] Code addition (extended unit tests, code cleanup ect that doesnt change functionality)

## Checklist:

- [x] I have formatted my code with black
- [x] I have checked my code with mypy
- [x] I have checked my code with pylint
- [x] I have ran the unit tests and they all pass
